### PR TITLE
Update wrgl

### DIFF
--- a/.wrgl/config.yaml
+++ b/.wrgl/config.yaml
@@ -1,8 +1,11 @@
 remote:
   origin:
-    url: https://hub.wrgl.co/api/users/ipno/repos/data
+    url: https://wrgl.llead.co
     fetch:
-      - +refs/heads/*:refs/remotes/data/*
+      - +refs/heads/event:refs/remotes/origin/event
+      - +refs/heads/personnel:refs/remotes/origin/personnel
+      - +refs/heads/documents:refs/remotes/origin/documents
+      - +refs/heads/news_article_classification:refs/remotes/origin/news_article_classification
 branch:
   event:
     remote: origin

--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@ communicate with external tools:
 
 ## wrgl
 
-[Install](https://www.wrgl.co/doc/guides/installation) wrgl binary and authenticate with
+Install (and update) with this snippet:
 
 ```bash
-wrgl credentials authenticate https://hub.wrgl.co/api
+sudo bash -c 'curl -L https://github.com/wrgl/wrgl/releases/latest/download/install.sh | bash'
 ```
+
+There's no need to authenticate before hand, it will ask you for credentials
+during push/pull as needed.
 
 ## dropbox
 

--- a/minutes/export/Makefile
+++ b/minutes/export/Makefile
@@ -25,7 +25,7 @@ clean:
 
 wrgl: $(output)
 	-wrgl init --wrgl-dir $(wrgldir)
-	wrgl pull documents --wrgl-dir $(wrgldir) --depth 1
+	wrgl pull documents --wrgl-dir $(wrgldir)
 	cd $(dir $(wrgldir)) && wrgl commit documents "updated documents"
 	wrgl push origin refs/heads/documents: --wrgl-dir $(wrgldir)
 

--- a/minutes/extract/import/Makefile
+++ b/minutes/extract/import/Makefile
@@ -30,7 +30,7 @@ force: ;
 # only locally within the recipe
 output/%.csv: force
 	-wrgl init --wrgl-dir $(wrgldir)
-	wrgl pull $* --wrgl-dir $(wrgldir) --depth 1
+	wrgl pull $* --wrgl-dir $(wrgldir)
 	wrgl export --wrgl-dir $(wrgldir) $* > $@
 
 $(output_mins): src/standardize-agency.R $(input_mins) $(agencies)

--- a/news-classification/export/Makefile
+++ b/news-classification/export/Makefile
@@ -14,7 +14,7 @@ all:
 
 wrgl: $(output)
 	-wrgl init --wrgl-dir $(wrgldir)
-	wrgl pull news_article_classification --wrgl-dir $(wrgldir) --depth 1
+	wrgl pull news_article_classification --wrgl-dir $(wrgldir)
 	cd $(dir $(wrgldir)) && wrgl commit news_article_classification "update news article classifications"
 	wrgl push origin refs/heads/news_article_classification: --wrgl-dir $(wrgldir)
 

--- a/news/import/officer-roster/Makefile
+++ b/news/import/officer-roster/Makefile
@@ -6,8 +6,7 @@
 input_personnel := output/working/personnel.csv
 input_event := output/working/event.csv
 
-wrglctl := ../../../share/bin/wrglctl
-wrgl_creds := ../../../share/creds/wrgl-creds.txt
+wrgldir := ../../../.wrgl
 
 output_roster := output/roster.parquet
 
@@ -27,9 +26,9 @@ force: ;
 # only locally within the recipe
 output/working/%.csv: force
 	-mkdir -p output/working
-	set -o allexport ; source $(wrgl_creds) ; set +o allexport ;\
-	$(wrglctl) login --apikey=$$WRGL_APIKEY;
-	$(wrglctl) repos pull @ipno/$* $@
+	-wrgl init --wrgl-dir $(wrgldir)
+	wrgl pull $* --wrgl-dir $(wrgldir)
+	wrgl export --wrgl-dir $(wrgldir) $* > $@
 
 $(output_roster): $(build_roster) $(input_personnel) $(input_event)
 	Rscript --vanilla $< \


### PR DESCRIPTION
- No need to authenticate the `wrgl` command from now on. You'll be asked to login via the browser when necessary. @tarakc02 your github handle should suffice.
- To make the entire pipeline run more predictably, it helps to run `wrgl pull --all` first. It'll take around 30 minutes when run for the first time. If you see an error like `block index at offset 0 has different sum`, just run it again until completion.